### PR TITLE
predab.resample() expects 'tolerance' to be passed along as 'tol'

### DIFF
--- a/R/validate.ols.s
+++ b/R/validate.ols.s
@@ -96,7 +96,7 @@ validate.ols <- function(fit, method="boot",
   
   predab.resample(fit.orig, method=method, fit=ols.fit, measure=discrim,
                   pr=pr, B=B, bw=bw, rule=rule, type=type, sls=sls, aics=aics,
-                  force=force, estimates=estimates, tolerance=tolerance,
+                  force=force, estimates=estimates, tol=tolerance,
                   backward=bw,u=u, penalty.matrix=penalty.matrix,
                   rel=rel, ...)
 }


### PR DESCRIPTION
I discovered this small bug when attempting to use validate() to perform bootstrapped backwards variable selection on a model built using ols(). The underlying solvet() function call was failing with the below error message:

Error in solvet(cov[q, q], beta[q], tol = eps) :
  apparently singular matrix

The solution was to provide a lower tolerance threshold, however the documented 'tolerance' parameter for validate.ols() was not being passed along the call chain. This small change fixed the issue for me in my local environment.
