### PR TITLE
Linetype parameter for ggplot.Predict()

### DIFF
--- a/R/ggplot.Predict.s
+++ b/R/ggplot.Predict.s
@@ -2,6 +2,7 @@ ggplot.Predict <-
   function(data, mapping, formula=NULL, groups=NULL,
            aestype=c('color', 'linetype'),
            conf=c('fill', 'lines'),
+           conflinetype=1,
            varypred=FALSE,
            sepdiscrete=c('no', 'list', 'vertical', 'horizontal'),
            subset, xlim., ylim., xlab, ylab,
@@ -277,8 +278,8 @@ ggplot.Predict <-
               if(conf == 'fill')
                 sprintf("geom_ribbon(aes(x=.xx., ymin=lower, ymax=upper),%s)",
                         ribbonargs)
-              else c("geom_line(aes(x=.xx., y=lower))",
-                     "geom_line(aes(x=.xx., y=upper))")
+              else c("geom_line(aes(x=.xx., y=lower), linetype=conflinetype)",
+                     "geom_line(aes(x=.xx., y=upper), linetype=conflinetype)")
             g <- c(g, h)
           }
 
@@ -500,8 +501,8 @@ ggplot.Predict <-
             if(conf == 'fill')
               sprintf("geom_ribbon(aes(ymin=lower, ymax=upper), %s)",
                       ribbonargs)
-            else c("geom_line(aes(x=.xx., y=lower))",
-                   "geom_line(aes(x=.xx., y=upper))")
+            else c("geom_line(aes(x=.xx., y=lower), linetype=conflinetype)",
+                   "geom_line(aes(x=.xx., y=upper), linetype=conflinetype)")
             ## geom_ribbon with fill=NA draws vertical lines at
             ## ends of confidence regions
           }
@@ -606,8 +607,8 @@ res <- if(jplot == 1) plrend(Plt[[1]])
           if(conf == 'fill')
             sprintf("geom_ribbon(data=data, aes(ymin=lower, ymax=upper),%s)",
                     ribbonargs)
-          else c(sprintf('geom_line(data=data, aes(x=%s, y=lower))', xn),
-                 sprintf('geom_line(data=data, aes(x=%s, y=upper))', xn))
+          else c(sprintf('geom_line(data=data, aes(x=%s, y=lower), linetype=conflinetype)', xn),
+                 sprintf('geom_line(data=data, aes(x=%s, y=upper), linetype=conflinetype)', xn))
         g <- c(g, h)
       }  # end if(conf.int)
     }

--- a/man/ggplot.Predict.Rd
+++ b/man/ggplot.Predict.Rd
@@ -25,6 +25,7 @@
 \method{ggplot}{Predict}(data, mapping, formula=NULL, groups=NULL,
      aestype=c('color', 'linetype'),
      conf=c('fill', 'lines'),
+     conflinetype=1,
      varypred=FALSE, sepdiscrete=c('no', 'list', 'vertical', 'horizontal'),
      subset, xlim., ylim., xlab, ylab, 
      colorscale=function(...) scale_color_manual(...,
@@ -74,6 +75,8 @@
 	\code{size}, \code{shape}.}
 \item{conf}{specify \code{conf="line"} to show confidence bands with
   lines instead of filled ribbons, the default}
+\item{conflinetype}{specify an alternative \code{linetype} for confidence
+  intervals if \code{conf="line"}}
 \item{varypred}{set to \code{TRUE} if \code{data} is the result of
   passing multiple \code{Predict} results, that represent different
   predictors, to \code{rbind.Predict}.  This will cause the \code{.set.}


### PR DESCRIPTION
Added conflinetype parameter to ggplot.Predict function to allow
dotted/dashed margins of confidence intervals