### PR TITLE
check for `stanloc` before beginning to compile

### DIFF
--- a/R/stanMisc.r
+++ b/R/stanMisc.r
@@ -179,6 +179,7 @@ stanCompile <-
   options(auto_write = FALSE)
   stanloc <- .Options$stancompiled
   if(! length(stanloc)) stop('options(stancompiled=) not defined')
+  if(! file.exists(stanloc)) stop('The directory defined in options(stancompiled=), \"', stanloc, '\" does not exist. Hint: see ?dir.create')
 
   cat('Compiling', length(mods), 'programs to', stanloc, '\n')
   for(m in mods) {


### PR DESCRIPTION
In the event that `stanloc` is set to a location which does not exist on the user's system, user will be notified with error _before_ beginning to compile, thus saving the user a few minutes of idle time.