### PR TITLE
kableExtra is now a suggested package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Title: Regression Modeling Strategies
 Author: Frank E Harrell Jr <fh@fharrell.com>
 Maintainer: Frank E Harrell Jr <fh@fharrell.com>
 Depends: R (>= 3.5.0), Hmisc (>= 4.8-0)
-Imports: methods, survival, quantreg, ggplot2, SparseM, rpart, nlme (>= 3.1-123), polspline, multcomp, htmlTable (>= 1.11.0), htmltools, MASS, cluster, digest, colorspace, kableExtra, knitr, grDevices
-Suggests: boot, tcltk, plotly (>= 4.5.6), mice, rmsb, nnet, VGAM, lattice
+Imports: methods, survival, quantreg, ggplot2, SparseM, rpart, nlme (>= 3.1-123), polspline, multcomp, htmlTable (>= 1.11.0), htmltools, MASS, cluster, digest, colorspace, knitr, grDevices
+Suggests: boot, tcltk, plotly (>= 4.5.6), mice, rmsb, nnet, VGAM, lattice, kableExtra
 Description: Regression modeling, testing, estimation, validation,
 	graphics, prediction, and typesetting by storing enhanced model design
 	attributes in the fit.  'rms' is a collection of functions that

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -34,7 +34,6 @@ import(multcomp)
 importFrom(htmlTable, htmlTable, txtRound)
 importFrom(htmltools, HTML)
 importFrom(knitr, kable)
-importFrom(kableExtra, kable_styling)
 
 importFrom(grDevices, dev.off, gray, grey, png, rgb, contourLines)
 importFrom(graphics, abline, axis, boxplot, hist, legend,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Changes in version 6.x-y (2023-xx-yy)
+   * kableExtra has been moved from Imports: to Suggests: and is used conditionally
+
 Changes in version 6.6-0 (2023-04-08)
    * latex.* for model fits: fixed case for file not blank, fixed bugs in latex.cph
    * Import knitr::kable and kableExtra::kable_styling and used these in latex.cph so that math notation can appear in html tables of survival probabilities

--- a/R/latex.cph.s
+++ b/R/latex.cph.s
@@ -51,10 +51,16 @@ latex.cph <-
   htmlTab <- function(s) {
     s <- cbind('$t$'= as.numeric(rownames(s)), s)
     for(j in 1 : ncol(s)) s[, j] <- round(s[, j], dec)
-    as.character(
-      knitr::kable(s, format='html',
-                   align='r', row.names=FALSE) |>
-      kableExtra::kable_styling(full_width=FALSE)   )
+    if (requireNamespace("kableExtra", quietly=TRUE)) {
+      as.character(
+        knitr::kable(s, format='html',
+                     align='r', row.names=FALSE) |>
+        kableExtra::kable_styling(full_width=FALSE)   )
+    } else {
+      as.character(
+        knitr::kable(s, format='html',
+                     align='r', row.names=FALSE) )
+    }
   }
   
   ss <- f$surv.summary


### PR DESCRIPTION
As discussed over email, this PR proposes to change the status of `kableExtra` to 'suggested' as is already done for a number of other packages.

The package still passes `R CMD check --as-cran` fine for me.

The changes are suggestive including the NEWS entry. If it, or the simple change to the R file, do not yet suit feel please do feel free to check out this branch and modify the PR as you see fit.  It is quick slick how GitHub lets you modify a PR branch.