### PR TITLE
Set a .gitattributes to guide language count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The .s files are for R
+*.s linguist-language=R
+# The files in ratfor/ are Fortran
+src/ratfor/*.r linguist-language=Fortran


### PR DESCRIPTION
This is what we sometimes call a 'quality-of-life' PR affecting only the GitHub repo and not the actual R package that matter so feel free to ignore it.

We set a file `.gitattributes` with content telling GitHub that `.s` files are in fact R files.  Then the language distribution 'guess' gets corrected as shown in this screenshot from my fork:

![image](https://user-images.githubusercontent.com/673121/233798732-f494ca93-4904-4e57-8899-d56fb41c10e5.png)

At your repo the majority is still  incorrectly shown as 'Assembly' which is very sweet in its own way for those of us who have been following `rms` (and `Hmisc`) since before they were CRAN packages and know the S history :smile: 