### PR TITLE
orm.fit outcome numerical precision fix

### DIFF
--- a/R/orm.fit.s
+++ b/R/orm.fit.s
@@ -48,12 +48,15 @@ orm.fit <- function(x=NULL, y,
       }
     }
 
-
+  y_new <- NULL
   ynumeric <- is.numeric(y)
   if(ynumeric) {
-    mediany <- quantile(y, probs=.5, type=1L)
-    yu <- sort(unique(y))
-    kmid <- max(1, which(yu == mediany) - 1L)
+	y_rnd <- round(y / tol)
+	mediany <- quantile(y_rnd, probs = 0.5, type = 1L)
+	yu <- sort(unique(y_rnd))
+	kmid <- max(1, which(yu == mediany) - 1L)
+	mediany <- mediany * tol
+	y_new <- match(y_rnd, yu)
   }
   # For large n, as.factor is slow
   # if(!is.factor(y)) y <- as.factor(y)
@@ -62,8 +65,13 @@ orm.fit <- function(x=NULL, y,
     y       <- unclass(y)
   }
   else {
-    ylevels <- sort(unique(y))
-    y       <- match(y, ylevels)
+	if(!is.null(y_new)) {
+		ylevels <- yu * tol
+		y       <- y_new
+	} else {
+		ylevels <- sort(unique(y))
+		y       <- match(y, ylevels)
+	}
   }
   if(! ynumeric) {
     mediany <- quantile(y, probs=.5, type=1L)

--- a/R/orm.fit.s
+++ b/R/orm.fit.s
@@ -51,6 +51,7 @@ orm.fit <- function(x=NULL, y,
   y_new <- NULL
   ynumeric <- is.numeric(y)
   if(ynumeric) {
+    mediany <- quantile(y, probs = 0.5, type = 1L)
     # need y.precision if any decimal places
 	needPrecision <- any(y %% 1 != 0)
     if(needPrecision) {
@@ -58,24 +59,20 @@ orm.fit <- function(x=NULL, y,
         # this is better than `round(y, y.precision)`
 	    y_rnd <- round(y * 10^y.precision)
 	    # median of "y"
-	    mediany <- quantile(y_rnd, probs = 0.5, type = 1L)
+	    mediany_rnd <- quantile(y_rnd, probs = 0.5, type = 1L)
         # unique values of "y"
 	    yu <- sort(unique(y_rnd))
+	    # convert whole number back to decimal
+		ylevels <- yu * 10^-y.precision
         # map "y" values from 1:n for `n` unique value
 	    y_new <- match(y_rnd, yu)
+    	# find the midpoint
+        kmid <- max(1, which(yu == mediany_rnd) - 1L)
 	} else {
-	    mediany <- quantile(y, probs = 0.5, type = 1L)
 	    yu <- sort(unique(y))
 		ylevels <- yu
-        # map "y" values from 1:n for `n` unique value
 	    y_new <- match(y, yu)
-	}
-	# find the midpoint
-	kmid <- max(1, which(yu == mediany) - 1L)
-    if(needPrecision) {
-	    # convert whole number back to decimal
-	    mediany <- mediany * 10^-y.precision
-		ylevels <- yu * 10^-y.precision
+	    kmid <- max(1, which(yu == mediany) - 1L)
 	}
   }
   # For large n, as.factor is slow

--- a/man/orm.fit.Rd
+++ b/man/orm.fit.Rd
@@ -70,7 +70,7 @@ derivative at each iteration.
   sample sizes where for example spline or polynomial component
   variables create scaling problems leading to loss of precision when
   accumulating sums of squares and crossproducts.}
-\item{y.precision}{When \quote{y} is numeric, values may need to be rounded
+\item{y.precision}{When \sQuote{y} is numeric, values may need to be rounded
 to avoid unpredictable behavior with floating-point numbers. Default is to
 7 decimal places.}
 }

--- a/man/orm.fit.Rd
+++ b/man/orm.fit.Rd
@@ -15,7 +15,7 @@
 \usage{
 orm.fit(x=NULL, y, family='logistic',
         offset=0., initial,  maxit=12L, eps=.005, tol=1e-7, trace=FALSE,
-        penalty.matrix=NULL, scale=FALSE)
+        penalty.matrix=NULL, scale=FALSE, y.precision = 7)
 }
 \arguments{
 \item{x}{
@@ -70,6 +70,9 @@ derivative at each iteration.
   sample sizes where for example spline or polynomial component
   variables create scaling problems leading to loss of precision when
   accumulating sums of squares and crossproducts.}
+\item{y.precision}{When \quote{y} is numeric, values may need to be rounded
+to avoid unpredictable behavior with floating-point numbers. Default is to
+7 decimal places.}
 }
 
 \value{


### PR DESCRIPTION
`unique` can have unpredictable behaviour with floating point values; better to make use of the "tol" argument.