### PR TITLE
apVar fix, require fixedSigma for glsApVar

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Changes in version 8.0-1 (2025-05-27)
    * intCalibration: added ordsurv option
    * predab.resample and validate.*: added approximate bootstrap confidence intervals for overfitting-corrected predictive performance measures using the method of Noma et al (2021)
    * validate.lrm: moved computation of Emax to inside bootstrap loop so can get approximate confidence limits
+   * Gls: complete "apVar" fix (see GH issue 157)
 
 Changes in version 8.0-0 (2025-04-04)
    * orm, orm.fit: implemented left, right, and interval censoring; added Dxy to orm.fit

--- a/R/Gls.s
+++ b/R/Gls.s
@@ -226,9 +226,11 @@ Gls <-
                                                      class(Resid) <- setdiff(cr, 'labelled')
     }
     
-    apVar <- if (FALSE && controlvals$apVar)    # see https://github.com/harrelfe/rms/issues/157
+    # fixedSimga should be set before `glsApVar`
+    attr(glsSt, 'fixedSigma') <- fixedSigma
+    apVar <- if (isTRUE(controlvals$apVar))    # see https://github.com/harrelfe/rms/issues/157
                glsApVar(glsSt, glsFit$sigma,
-                        .relStep  = controlvals[[".relStep"]],  
+                        .relStep  = controlvals[[".relStep"]],
                         minAbsPar = controlvals[["minAbsParApVar"]],
                         natural   = controlvals[["natural"]])
              else
@@ -237,7 +239,6 @@ Gls <-
     dims[["p"]] <- p
     attr(glsSt, "conLin") <- NULL
     attr(glsSt, "glsFit") <- NULL
-    attr(glsSt, 'fixedSigma') <- fixedSigma
     grpDta <- inherits(data, 'groupedData')
     estOut <- list(modelStruct = glsSt, dims = dims, contrasts = contr, 
                    coefficients = glsFit[["beta"]], varBeta = varBeta,


### PR DESCRIPTION
This should complete the fix for #157 -- the "glsSt" object needs "fixedSigma" attribute before the `glsApVar` call